### PR TITLE
Issue 2: add edit ability to transfers

### DIFF
--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -10,48 +10,64 @@ const PAGE_SIZE = 10;
 import { db } from "../data";
 const transferService = new TransferService(db);
 
-transferRouter.post("/", [body("page").isInt().default(1), body("itemsPerPage").isInt().default(10)],
+transferRouter.post(
+    "/",
+    [body("page").isInt().default(1), body("itemsPerPage").isInt().default(10)],
     async (req: Request, res: Response) => {
         let { query, sortBy, sortDesc, page, itemsPerPage } = req.body;
         let sort = new Array<SortStatement>();
 
         sortBy.forEach((s: string, i: number) => {
-            sort.push({ field: s, direction: sortDesc[i] ? SortDirection.ASCENDING : SortDirection.DESCENDING })
-        })
+            sort.push({
+                field: s,
+                direction: sortDesc[i]
+                    ? SortDirection.ASCENDING
+                    : SortDirection.DESCENDING,
+            });
+        });
 
         let skip = (page - 1) * itemsPerPage;
         let take = itemsPerPage;
 
-        let results = await transferService.doSearch(query, sort, page, itemsPerPage, skip, take);
+        let results = await transferService.doSearch(
+            query,
+            sort,
+            page,
+            itemsPerPage,
+            skip,
+            take
+        );
 
         return res.json(results);
+    }
+);
+
+transferRouter.post("/transfer", async (req: Request, res: Response) => {
+    let { from_owner_id, to_owner_id, rows, action } = req.body;
+
+    for (let row of rows) {
+        let transfer = {
+            asset_category_id: row.type,
+            request_user: req.user.email,
+            request_date: new Date(),
+            transfer_date: new Date(),
+            condition: row.condition,
+            from_owner_id,
+            to_owner_id,
+            quantity: row.quantity,
+            description: row.tag,
+        };
+
+        await db("asset_transfer").insert(transfer);
+    }
+
+    return res.json({
+        messages: { variant: "success", text: "Transfer saved" },
     });
+});
 
-transferRouter.post("/transfer",
-    async (req: Request, res: Response) => {
-        let { from_owner_id, to_owner_id, rows, action } = req.body;
-
-        for (let row of rows) {
-            let transfer = {
-                asset_category_id: row.type,
-                request_user: req.user.email,
-                request_date: new Date(),
-                transfer_date: new Date(),
-                condition: row.condition,
-                from_owner_id,
-                to_owner_id,
-                quantity: row.quantity,
-                description: row.tag
-            }
-
-            await db("asset_transfer").insert(transfer);
-        }
-
-        return res.json({ messages: { variant: "success", text: "Transfer saved" } });
-    });
-
-
-transferRouter.post("/transfer-request",
+transferRouter.post(
+    "/transfer-request",
     async (req: Request, res: Response) => {
         let { asset, mailcode, rows, condition } = req.body;
 
@@ -64,12 +80,11 @@ transferRouter.post("/transfer-request",
                 condition: `REQUEST: ${condition}`,
                 from_owner_id: mailcode,
                 to_owner_id: 80,
-                quantity: 1
+                quantity: 1,
             };
 
             await db("asset_transfer").insert(transfer);
-        }
-        else {
+        } else {
             for (let row of rows) {
                 let transfer = {
                     asset_category_id: row.type,
@@ -79,19 +94,21 @@ transferRouter.post("/transfer-request",
                     condition: `REQUEST: ${row.condition}`,
                     from_owner_id: mailcode,
                     to_owner_id: 80,
-                    quantity: row.quantity
+                    quantity: row.quantity,
                 };
 
                 await db("asset_transfer").insert(transfer);
             }
         }
 
-        return res.json({ messages: { variant: "success", text: "Transfer saved" } });
-    });
-
+        return res.json({
+            messages: { variant: "success", text: "Transfer saved" },
+        });
+    }
+);
 
 transferRouter.delete("/:id", async (req: Request, res: Response) => {
-    let { id } = req.params;
+    const { id } = req.params;
 
     await db("asset_transfer").where({ id }).delete();
     return res.json({
@@ -100,11 +117,13 @@ transferRouter.delete("/:id", async (req: Request, res: Response) => {
     });
 });
 
-transferRouter.get("/clean",
-    async (req: Request, res: Response) => {
-        let { id } = req.params;
+transferRouter.get("/clean", async (req: Request, res: Response) => {
+    let { id } = req.params;
 
-        await transferService.clean();
+    await transferService.clean();
 
-        return res.json({ data: {}, messages: [{ variant: "success", text: "Location removed" }] });
+    return res.json({
+        data: {},
+        messages: [{ variant: "success", text: "Location removed" }],
     });
+});

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -107,6 +107,37 @@ transferRouter.post(
     }
 );
 
+transferRouter.patch("/:id", async (req: Request, res: Response) => {
+    const { id } = req.params;
+
+    const {
+        to_owner_id,
+        from_owner_id,
+        description,
+        quantity,
+        condition,
+        asset_item,
+    } = req.body;
+
+    await db("asset_transfer").where({ id }).update({
+        to_owner_id,
+        from_owner_id,
+        description,
+        quantity,
+        condition,
+    });
+
+    if (asset_item?.tag) {
+        const { id: asset_item_id, tag } = asset_item;
+        await db("asset_item").where({ id: asset_item_id }).update({ tag });
+    }
+
+    return res.json({
+        data: {},
+        messages: [{ variant: "success", text: "Transfer saved" }],
+    });
+});
+
 transferRouter.delete("/:id", async (req: Request, res: Response) => {
     const { id } = req.params;
 

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -116,6 +116,7 @@ transferRouter.patch("/:id", async (req: Request, res: Response) => {
         description,
         quantity,
         condition,
+        asset_item_id,
         asset_item,
     } = req.body;
 
@@ -127,9 +128,11 @@ transferRouter.patch("/:id", async (req: Request, res: Response) => {
         condition,
     });
 
-    if (asset_item?.tag) {
-        const { id: asset_item_id, tag } = asset_item;
-        await db("asset_item").where({ id: asset_item_id }).update({ tag });
+    if (asset_item_id) {
+        const { id: asset_item_id, tag, description } = asset_item;
+        await db("asset_item")
+            .where({ id: asset_item_id })
+            .update({ tag, description });
     }
 
     return res.json({

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -111,29 +111,20 @@ transferRouter.patch("/:id", async (req: Request, res: Response) => {
     const { id } = req.params;
 
     const {
-        to_owner_id,
-        from_owner_id,
-        description,
-        quantity,
+        asset_category_id,
         condition,
-        asset_item_id,
-        asset_item,
+        from_owner_id,
+        quantity,
+        to_owner_id,
     } = req.body;
 
     await db("asset_transfer").where({ id }).update({
-        to_owner_id,
-        from_owner_id,
-        description,
-        quantity,
+        asset_category_id,
         condition,
+        from_owner_id,
+        quantity,
+        to_owner_id,
     });
-
-    if (asset_item_id) {
-        const { id: asset_item_id, tag, description } = asset_item;
-        await db("asset_item")
-            .where({ id: asset_item_id })
-            .update({ tag, description });
-    }
 
     return res.json({
         data: {},

--- a/web/src/components/transfers/TransferEditor.vue
+++ b/web/src/components/transfers/TransferEditor.vue
@@ -17,7 +17,6 @@
         <div class="col-sm-6">
           <v-autocomplete
             dense
-            disabled
             outlined
             label="To"
             :items="ownerOptions"
@@ -31,7 +30,6 @@
         <div class="col-sm-6">
           <v-autocomplete
             dense
-            disabled
             outlined
             label="From"
             :items="ownerOptions"
@@ -50,7 +48,6 @@
         <div class="col-sm-6">
           <v-text-field
             dense
-            disabled
             outlined
             label="Description"
             hide-details
@@ -61,7 +58,6 @@
         <div class="col-sm-6">
           <v-text-field
             dense
-            disabled
             outlined
             label="Departmental tag"
             hide-details
@@ -71,7 +67,6 @@
         <div class="col-sm-3">
           <v-text-field
             dense
-            disabled
             outlined
             label="Quantity"
             type="number"
@@ -83,7 +78,6 @@
         <div class="col-sm-7">
           <v-select
             dense
-            disabled
             outlined
             label="Condition"
             hide-details
@@ -92,13 +86,19 @@
           ></v-select>
         </div>
       </div>
-      <v-btn
-        class="float-right"
-        color="error"
-        :loading="loading"
-        @click="confirmDelete"
+
+      <v-btn color="error" :loading="loading" @click="confirmDelete"
         >Remove</v-btn
       >
+      <v-btn
+        color="primary"
+        class="float-right"
+        :disabled="!isValid"
+        :loading="loading"
+        @click="save"
+        >Save</v-btn
+      >
+
       <v-dialog v-model="isShowingDeleteDialog" max-width="290">
         <v-card>
           <v-card-title> Confirm Deletion </v-card-title>
@@ -113,14 +113,6 @@
           </v-card-actions>
         </v-card>
       </v-dialog>
-      <!-- <v-btn
-        @click="save"
-        color="primary"
-        class="float-right"
-        :disabled="loading || !isValid"
-        :loading="loading"
-        >Save</v-btn
-      > -->
     </v-sheet>
   </v-navigation-drawer>
 </template>
@@ -199,11 +191,30 @@ export default {
         });
     },
     save() {
-      const body = _.clone(this.item);
+      const {
+        id,
+        to_owner_id,
+        from_owner_id,
+        description,
+        quantity,
+        condition,
+        asset_item_id,
+      } = this.item;
+      const asset_item = {
+        id: asset_item_id,
+        tag: this.assetItemTag,
+      };
 
       this.loading = true;
       axios
-        .put(`${TRANSFER_URL}/${this.item.id}`, body)
+        .patch(`${TRANSFER_URL}/${id}`, {
+          to_owner_id,
+          from_owner_id,
+          description,
+          quantity,
+          condition,
+          asset_item,
+        })
         .then((resp) => {
           if (this.onSave) {
             this.onSave(resp);

--- a/web/src/components/transfers/TransferEditor.vue
+++ b/web/src/components/transfers/TransferEditor.vue
@@ -180,7 +180,11 @@ export default {
     },
     hide() {
       this.item = {};
+      this.assetItem = {};
+      this.assetCategory = {};
       this.drawer = false;
+      this.loading = false;
+      this.isShowingDeleteDialog = false;
     },
     loadList() {
       this.loading = true;

--- a/web/src/components/transfers/TransferEditor.vue
+++ b/web/src/components/transfers/TransferEditor.vue
@@ -200,9 +200,11 @@ export default {
         condition,
         asset_item_id,
       } = this.item;
+
       const asset_item = {
         id: asset_item_id,
         tag: this.assetItemTag,
+        description: description,
       };
 
       this.loading = true;
@@ -213,6 +215,7 @@ export default {
           description,
           quantity,
           condition,
+          asset_item_id,
           asset_item,
         })
         .then((resp) => {

--- a/web/src/components/transfers/TransferEditor.vue
+++ b/web/src/components/transfers/TransferEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-navigation-drawer v-model="drawer" temporary absolute right width="700px">
+  <v-navigation-drawer v-model="drawer" temporary app right width="700px">
     <v-list-item>
       <v-list-item-avatar>
         <v-icon>mdi-swap-horizontal-bold</v-icon>


### PR DESCRIPTION
## Fixes:
- https://github.com/icefoganalytics/asset-apps/issues/1

## Depends on:
- https://github.com/icefoganalytics/asset-apps/pull/3

## Context

Add ability to edit transfers.

`asset_tranfer` with an `asset_item_id` (read only)
![image](https://user-images.githubusercontent.com/23045206/154548228-7eaf5dd5-f71d-48f5-b131-a19e8345d52f.png)

`asset_transfer` with a `asset_category_id` (editable by selecting another category)
![image](https://user-images.githubusercontent.com/23045206/154548485-85efff4f-621e-4407-9468-71bb4262076a.png)

