### PR TITLE
Issue 12: Require Authentication by default on all API routes

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Express, NextFunction, Request, Response } from "express"
+import { Express, NextFunction, Request, Response } from "express";
 import * as ExpressSession from "express-session";
 import { AuthUser } from "../data";
 import { AUTH_REDIRECT, FRONTEND_URL } from "../config";
@@ -8,28 +8,52 @@ import { auth } from "express-openid-connect";
 
 const db = new UserService();
 
-export function configureAuthentication(app: Express) {
-
-    app.use(ExpressSession.default({
-        secret: 'supersecret',
-        resave: true,
-        saveUninitialized: true
-    }));
-
-    app.use(auth({
-        authRequired: false,
-        auth0Logout: false,
-        authorizationParams: {
-            response_type: 'code',
-            audience: '',
-            scope: 'openid profile email',
-        },
-        routes: {
-            login: "/api/auth/login",
-            //logout: "/api/auth/logout",
-            postLogoutRedirect: FRONTEND_URL
+function authenticationForEverywhereExcept(excludes: string[]) {
+    return (req: Request, res: Response, next: NextFunction) => {
+        if (excludes.includes(req.path)) {
+            return next();
         }
-    }));
+
+        if (req.oidc.isAuthenticated()) {
+            return next();
+        }
+
+        res.status(401).send("Not authenticated");
+    };
+}
+
+export function configureAuthentication(app: Express) {
+    app.use(
+        ExpressSession.default({
+            secret: "supersecret",
+            resave: true,
+            saveUninitialized: true,
+        })
+    );
+
+    app.use(
+        auth({
+            authRequired: false,
+            auth0Logout: false,
+            authorizationParams: {
+                response_type: "code",
+                audience: "",
+                scope: "openid profile email",
+            },
+            routes: {
+                login: "/api/auth/login",
+                //logout: "/api/auth/logout",
+                postLogoutRedirect: FRONTEND_URL,
+            },
+        })
+    );
+
+    app.use(
+        authenticationForEverywhereExcept([
+            "/api/auth/login",
+            "/api/auth/isAuthenticated",
+        ])
+    );
 
     app.use("/", async (req: Request, res: Response, next: NextFunction) => {
         if (req.oidc.isAuthenticated()) {
@@ -52,40 +76,40 @@ export function configureAuthentication(app: Express) {
             let dbUser = await db.getByEmail(req.user.email);
 
             if (!dbUser) {
-                console.log("CREATING USER")
-                await db.create(user.email, user.first_name, user.last_name, "Active", "");
+                console.log("CREATING USER");
+                await db.create(
+                    user.email,
+                    user.first_name,
+                    user.last_name,
+                    "Active",
+                    ""
+                );
             }
 
             res.redirect(AUTH_REDIRECT);
-        }
-        else {
+        } else {
             // this is hard-coded to accomodate strage behaving in sendFile not allowing `../` in the path.
             // this won't hit in development because web access is served by the Vue CLI - only an issue in Docker
-            res.sendFile("/home/node/app/dist/web/index.html")
+            res.sendFile("/home/node/app/dist/web/index.html");
         }
     });
 
-    app.get("/api/auth/isAuthenticated", async (req: Request, res: Response) => {
-        if (req.oidc.isAuthenticated()) {
-            let person = req.user;
-            //let me = await db.getByEmail(person.email);
-            return res.json({ data: person });
+    app.get(
+        "/api/auth/isAuthenticated",
+        async (req: Request, res: Response) => {
+            if (req.oidc.isAuthenticated()) {
+                let person = req.user;
+                //let me = await db.getByEmail(person.email);
+                return res.json({ data: person });
+            }
+
+            return res.status(401).send();
         }
+    );
 
-        return res.status(401).send();
-    });
-
-    app.get('/api/auth/logout', async (req: any, res) => {
+    app.get("/api/auth/logout", async (req: any, res) => {
         req.session.destroy();
-        res.status(401)
+        res.status(401);
         await (res as any).oidc.logout();
     });
-}
-
-export function EnsureAuthenticated(req: Request, res: Response, next: NextFunction) {
-    if (req.oidc.isAuthenticated()) {
-        return next();
-    }
-
-    res.status(401).send("Not authenticated"); //;.redirect('/api/auth/login');
 }

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -98,12 +98,10 @@ export function configureAuthentication(app: Express) {
         "/api/auth/is-authenticated",
         async (req: Request, res: Response) => {
             if (req.oidc.isAuthenticated()) {
-                let person = req.user;
-                //let me = await db.getByEmail(person.email);
-                return res.json({ data: person });
+                return res.json({ data: true });
             }
 
-            return res.status(401).send();
+            return res.json({ data: false });
         }
     );
 

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -51,7 +51,7 @@ export function configureAuthentication(app: Express) {
     app.use(
         authenticationForEverywhereExcept([
             "/api/auth/login",
-            "/api/auth/isAuthenticated",
+            "/api/auth/is-authenticated",
         ])
     );
 
@@ -95,7 +95,7 @@ export function configureAuthentication(app: Express) {
     });
 
     app.get(
-        "/api/auth/isAuthenticated",
+        "/api/auth/is-authenticated",
         async (req: Request, res: Response) => {
             if (req.oidc.isAuthenticated()) {
                 let person = req.user;

--- a/api/src/routes/user-router.ts
+++ b/api/src/routes/user-router.ts
@@ -3,32 +3,31 @@ import { body, param } from "express-validator";
 import { ReturnValidationErrors } from "../middleware";
 import { UserService } from "../services";
 import _ from "lodash";
-import { EnsureAuthenticated } from "./auth";
 
 export const userRouter = express.Router();
 
 const db = new UserService();
 
-userRouter.get("/me", EnsureAuthenticated,
-    async (req: Request, res: Response) => {
-        let person = req.user;
-        let me = await db.getByEmail(person.email);
-        return res.json({ data: await db.makeDTO(Object.assign(req.user, me)) });
-    });
+userRouter.get("/me", async (req: Request, res: Response) => {
+    let person = req.user;
+    let me = await db.getByEmail(person.email);
+    return res.json({ data: await db.makeDTO(Object.assign(req.user, me)) });
+});
 
-userRouter.get("/", EnsureAuthenticated,
-    async (req: Request, res: Response) => {
-        let list = await db.getAll();
+userRouter.get("/", async (req: Request, res: Response) => {
+    let list = await db.getAll();
 
-        for (let user of list) {
-            user = await db.makeDTO(user)
-        }
+    for (let user of list) {
+        user = await db.makeDTO(user);
+    }
 
-        return res.json({ data: list });
-    });
+    return res.json({ data: list });
+});
 
-userRouter.put("/:email", EnsureAuthenticated,
-    [param("email").notEmpty().isString()], ReturnValidationErrors,
+userRouter.put(
+    "/:email",
+    [param("email").notEmpty().isString()],
+    ReturnValidationErrors,
     async (req: Request, res: Response) => {
         let { email } = req.params;
         let { roles, status, mailcode, manage_mailcodes } = req.body;
@@ -42,11 +41,16 @@ userRouter.put("/:email", EnsureAuthenticated,
 
         await db.update(email, user);
 
-        return res.json({ messages: [{ variant: "success", text: "User saved" }] });
-    });
+        return res.json({
+            messages: [{ variant: "success", text: "User saved" }],
+        });
+    }
+);
 
-userRouter.put("/:email/mailcode", EnsureAuthenticated,
-    [param("email").notEmpty().isString(), body("mailcode").notEmpty()], ReturnValidationErrors,
+userRouter.put(
+    "/:email/mailcode",
+    [param("email").notEmpty().isString(), body("mailcode").notEmpty()],
+    ReturnValidationErrors,
     async (req: Request, res: Response) => {
         let { email } = req.params;
         let { mailcode } = req.body;
@@ -56,14 +60,19 @@ userRouter.put("/:email/mailcode", EnsureAuthenticated,
         if (user) {
             user.mailcode = mailcode;
             await db.update(email, user);
-            return res.json({ messages: [{ variant: "success", text: "Mail code saved" }] });
+            return res.json({
+                messages: [{ variant: "success", text: "Mail code saved" }],
+            });
         }
 
         res.status(404).send();
-    });
+    }
+);
 
-userRouter.delete("/:id", EnsureAuthenticated,
-    [param("id").notEmpty()], ReturnValidationErrors,
+userRouter.delete(
+    "/:id",
+    [param("id").notEmpty()],
+    ReturnValidationErrors,
     async (req: Request, res: Response) => {
         let { id } = req.params;
 
@@ -71,10 +80,15 @@ userRouter.delete("/:id", EnsureAuthenticated,
 
         let list = await db.getAll();
 
-        return res.json({ data: list, messages: [{ variant: "success", text: "Location removed" }] });
-    });
+        return res.json({
+            data: list,
+            messages: [{ variant: "success", text: "Location removed" }],
+        });
+    }
+);
 
-userRouter.get("/make-admin/:email/:key",
+userRouter.get(
+    "/make-admin/:email/:key",
     async (req: Request, res: Response) => {
         let user = await db.getByEmail(req.params.email);
 
@@ -91,4 +105,5 @@ userRouter.get("/make-admin/:email/:key",
         }
 
         res.send("Done");
-    });
+    }
+);

--- a/bin/dev-completions.sh
+++ b/bin/dev-completions.sh
@@ -1,0 +1,3 @@
+# usage `source bin/dev-completions.sh`
+
+complete -W "$(bash -ec ". bin/dev; typeset -f | grep -Po '(\w*?)(?= \(\))' | tr '\n' ' '")" dev

--- a/web/src/store/auth.js
+++ b/web/src/store/auth.js
@@ -1,49 +1,45 @@
 import axios from "axios";
+
 import { AUTH_CHECK_URL, LOGOUT_URL } from "../urls";
 
 const state = {
-    user: null,
-    fullName: "",
-    roles: []
+    isAuthenticated: false,
 };
 const getters = {
-    isAuthenticated: state => !!state.user,
-    fullName: state => { return state.fullName },
-    roles: state => { return state.roles }
+    isAuthenticated: (state) => state.isAuthenticated,
 };
 const actions = {
     async checkAuthentication({ commit }) {
-        await axios.get(AUTH_CHECK_URL)
-            .then(resp => {
-                commit("setUser", resp.data.data);
-            }).catch(() => {
-                commit("clearUser");
+        await axios
+            .get(AUTH_CHECK_URL)
+            .then((resp) => {
+                commit("setIsAuthenticated", resp.data.data);
+            })
+            .catch(() => {
+                commit("setIsAuthenticated", false);
+                commit("clearProfile");
             });
     },
     async signOut({ commit }) {
-        await axios.get(LOGOUT_URL)
+        await axios
+            .get(LOGOUT_URL)
             .then(() => {
-                commit("clearUser");
-            }).catch(err => {
-                console.error(err);
+                commit("clearProfile");
+            })
+            .catch((error) => {
+                console.error(error);
             });
-    }
+    },
 };
 const mutations = {
-    setUser(state, user) {
-        state.user = user;
-        state.fullName = user.display_name;
-        state.roles = user.roles;
+    setIsAuthenticated(state, value) {
+        state.isAuthenticated = value;
     },
-    clearUser(state) {
-        state.user = null;
-        state.fullName = null;
-    }
 };
 
 export default {
     state,
     getters,
     actions,
-    mutations
+    mutations,
 };

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -31,7 +31,6 @@ export default new Vuex.Store({
     initialize() {
       console.log("Initializing Store");
       this.dispatch("loadMailcodes");
-      this.dispatch("loadAssetConditionOptions");
       this.dispatch("loadAssetTypeOptions");
     },
 

--- a/web/src/store/profile.js
+++ b/web/src/store/profile.js
@@ -2,44 +2,60 @@ import axios from "axios";
 import { PROFILE_URL } from "../urls";
 
 const state = {
-    firstName: "",
-    lastName: "",
     email: "",
+    firstName: "",
+    fullName: "",
     id: "",
-    username: "",
+    lastName: "",
     mailcode: "",
-    roles: "",
-    manage_mailcodes: "",
+    manage_mailcodes: [],
+    roles: [],
 };
+
 const getters = {
-    firstName: state => state.firstName,
-    lastName: state => state.lastName,
-    email: state => state.email,
-    id: state => state.id,
-    username: state => state.username,
-    mailcode: state => state.mailcode,
-    roles: state => state.roles,
-    manage_mailcodes: state => state.manage_mailcodes,
+    email: (state) => state.email,
+    firstName: (state) => state.firstName,
+    fullName: (state) => state.fullName,
+    id: (state) => state.id,
+    lastName: (state) => state.lastName,
+    mailcode: (state) => state.mailcode,
+    manage_mailcodes: (state) => state.manage_mailcodes,
+    roles: (state) => state.roles,
 };
 const actions = {
-    async loadProfile({ commit }) {
-        await axios.get(PROFILE_URL)
-            .then(resp => {
+    loadProfile({ commit }) {
+        return axios
+            .get(PROFILE_URL)
+            .then((resp) => {
                 commit("setProfile", resp.data.data);
-            }).catch(() => {
-                commit("clearUser");
+            })
+            .catch(() => {
+                commit("clearProfile");
             });
     },
 };
 const mutations = {
     setProfile(state, profile) {
-        state.firstName = profile.first_name;
-        state.lastName = profile.last_name;
         state.email = profile.email;
-        state.status = profile.status;
+        state.firstName = profile.first_name;
+        state.fullName = profile.display_name;
+        state.lastName = profile.last_name;
         state.mailcode = profile.mailcode;
-        state.roles = profile.roles;
         state.manage_mailcodes = profile.manage_mailcodes;
+        state.roles = profile.roles;
+        state.status = profile.status;
+    },
+    clearProfile(state) {
+        Object.assign(state, {
+            email: "",
+            firstName: "",
+            fullName: "",
+            id: "",
+            lastName: "",
+            mailcode: "",
+            manage_mailcodes: [],
+            roles: [],
+        });
     },
 };
 
@@ -48,5 +64,5 @@ export default {
     state,
     getters,
     actions,
-    mutations
+    mutations,
 };

--- a/web/src/urls.js
+++ b/web/src/urls.js
@@ -1,8 +1,7 @@
-
 import * as config from "./config";
 
 export const LOGIN_URL = `${config.apiBaseUrl}/api/auth/login`;
-export const AUTH_CHECK_URL = `${config.apiBaseUrl}/api/auth/isAuthenticated`;
+export const AUTH_CHECK_URL = `${config.apiBaseUrl}/api/auth/is-authenticated`;
 export const LOGOUT_URL = `${config.apiBaseUrl}/api/auth/logout`;
 export const PROFILE_URL = `${config.apiBaseUrl}/api/user/me`;
 export const USER_URL = `${config.apiBaseUrl}/api/user`;


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/asset-apps/issues/12

## Context

Enforce authorization by default on back-end API routes except `/api/auth/login` and `/api/auth/is-authenticated`.
Rework App.vue to only initialize the store once a user has been authenticated.
Rework store "auth" module to use boolean isAuthenticated check.
Push all user related content from store "auth" to store "profile" module.

## Testing instructions

1. Boot the app and check that the main pages doesn't throw any errors in the console when you are not logged in `http://localhost:8080/`
2. Check that once logged in you can access `http://localhost:3000/api/asset-owner`.
3. Logout of the app.
4. Check that your user profile gets wiped from the Vuex store 
![image](https://user-images.githubusercontent.com/23045206/155222911-cf6753ff-5915-4780-be0d-6da0f44ba1dd.png)
5. Check that you can no longer access the back-end API `http://localhost:3000/api/asset-owner`
![image](https://user-images.githubusercontent.com/23045206/155223039-71bb0dda-94e6-4041-9a9c-121e8d7af4a9.png)

