### PR TITLE
Fixup: Back-end Authentication is too Strict

### DIFF
--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -64,6 +64,7 @@ export function configureAuthentication(app: Express) {
 
     app.use(
         oidcAuthenticationForEverywhereExcept([
+            /^(?<!\/api\/).*$/,
             /^\/api\/auth\/login$/,
             /^\/api\/auth\/is-authenticated$/,
             V2_API_REGEX,


### PR DESCRIPTION
Ignore authentication on any route that doesn't start with `/api/` as the production site has the back-end serving the complied front-end code at `/` and `/etc/etc`.