### PR TITLE
Issue 23: Tweak Tag Request Form

### DIFF
--- a/web/src/components/AssetRegisterForm.vue
+++ b/web/src/components/AssetRegisterForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-form v-model="valid">
+  <v-form v-model="isValid">
     <v-alert color="warning" border="left" outlined backround-color="#fffffdd">
       <h4 class="mb-2">YG assets valued over $1000 must have an asset tag</h4>
       <p class="mb-0">
@@ -23,7 +23,6 @@
           <v-col cols="4">
             <v-text-field
               v-model="tagCount"
-              label="How many tags do you need?"
               :rules="tagCountRules"
               hide-details="auto"
               dense
@@ -32,7 +31,11 @@
               min="1"
               max="50"
               required
-            ></v-text-field>
+            >
+              <template #label>
+                How many tags do you need? <strong class="red--text">*</strong>
+              </template>
+            </v-text-field>
           </v-col>
 
           <v-col cols="8">
@@ -44,13 +47,12 @@
               nudge-top="26"
               offset-y
               min-width="auto"
-              required
             >
               <template v-slot:activator="{ on, attrs }">
                 <v-text-field
                   v-model="purchaseDate"
-                  label="Purchase date"
                   append-icon="mdi-calendar"
+                  required
                   readonly
                   outlined
                   hide-details="auto"
@@ -58,7 +60,11 @@
                   background-color="white"
                   v-bind="attrs"
                   v-on="on"
-                ></v-text-field>
+                >
+                  <template #label>
+                    Purchase date <strong class="red--text">*</strong>
+                  </template>
+                </v-text-field>
               </template>
               <v-date-picker
                 v-model="purchaseDate"
@@ -75,13 +81,17 @@
               :items="onlyKnownMailcodeOptions"
               item-text="display_name"
               item-value="id"
-              label="What mail code do we send them to?"
               :rules="sendMailcodeIdRules"
               hide-details="auto"
               dense
               outlined
               required
-            ></v-autocomplete>
+            >
+              <template #label>
+                What mail code do we send them to?
+                <strong class="red--text">*</strong>
+              </template>
+            </v-autocomplete>
           </v-col>
         </v-row>
 
@@ -92,36 +102,46 @@
               :items="assetPurchaseTypeOptions"
               item-text="description"
               item-value="id"
-              label="How were these items purchased?"
               :rules="assetPurchaseTypeIdRules"
               hide-details="auto"
               dense
               outlined
               required
-            ></v-select>
+            >
+              <template #label>
+                How were these items purchased?
+                <strong class="red--text">*</strong>
+              </template>
+            </v-select>
           </v-col>
           <v-col cols="6">
             <v-text-field
               v-model="orderNumber"
               label="Order number"
-              :rules="orderNumberRules"
-              hide-details="auto"
+              hide-details
               dense
               outlined
-              required
             ></v-text-field>
           </v-col>
         </v-row>
 
         <div class="d-flex justify-end">
-          <v-btn
-            class="mb-0"
-            color="primary"
-            :disabled="!valid"
-            @click="createTags"
-          >
-            Generate tags
-          </v-btn>
+          <v-tooltip left :disabled="isValid">
+            <template v-slot:activator="{ on }">
+              <div v-on="on">
+                <v-btn
+                  class="mb-0"
+                  color="primary"
+                  append-icon=""
+                  :disabled="!isValid"
+                  @click="createTags"
+                >
+                  Generate tags
+                </v-btn>
+              </div>
+            </template>
+            <span>Please fill in all required fields</span>
+          </v-tooltip>
         </div>
       </v-container>
     </v-card>
@@ -157,7 +177,6 @@ export default {
     return {
       datePickerMenu: false,
       orderNumber: null,
-      orderNumberRules: [(v) => !!v || "Order number is required"],
       purchaseDate: null,
       purchasedTypeId: null,
       assetPurchaseTypeIdRules: [(v) => !!v || "Purchase type is required"],
@@ -168,7 +187,7 @@ export default {
         (v) => !!v || "Must request at least one tag",
         (v) => v > 0 || "Must request at least one tag",
       ],
-      valid: false,
+      isValid: false,
     };
   },
   mounted() {

--- a/web/src/components/AssetRegisterForm.vue
+++ b/web/src/components/AssetRegisterForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="">
+  <v-form v-model="valid">
     <v-alert color="warning" border="left" outlined backround-color="#fffffdd">
       <h4 class="mb-2">YG assets valued over $1000 must have an asset tag</h4>
       <p class="mb-0">
@@ -22,26 +22,29 @@
         <v-row>
           <v-col cols="4">
             <v-text-field
+              v-model="tagCount"
               label="How many tags do you need?"
+              :rules="tagCountRules"
+              hide-details="auto"
               dense
               outlined
-              hide-details
               type="number"
               min="1"
               max="50"
-              v-model="tagCount"
+              required
             ></v-text-field>
           </v-col>
 
           <v-col cols="8">
             <v-menu
-              v-model="menu"
+              v-model="datePickerMenu"
               :close-on-content-click="false"
               transition="scale-transition"
               left
               nudge-top="26"
               offset-y
               min-width="auto"
+              required
             >
               <template v-slot:activator="{ on, attrs }">
                 <v-text-field
@@ -50,7 +53,7 @@
                   append-icon="mdi-calendar"
                   readonly
                   outlined
-                  hide-details
+                  hide-details="auto"
                   dense
                   background-color="white"
                   v-bind="attrs"
@@ -59,7 +62,7 @@
               </template>
               <v-date-picker
                 v-model="purchaseDate"
-                @input="menu = false"
+                @input="datePickerMenu = false"
               ></v-date-picker>
             </v-menu>
           </v-col>
@@ -68,51 +71,62 @@
         <v-row>
           <v-col cols="12">
             <v-autocomplete
-              dense
-              outlined
-              hide-details
-              :items="onlyKnownMailcodeOptions"
-              label="What mail code do we send them to?"
               v-model="sendMailcodeId"
+              :items="onlyKnownMailcodeOptions"
               item-text="display_name"
               item-value="id"
+              label="What mail code do we send them to?"
+              :rules="sendMailcodeIdRules"
+              hide-details="auto"
+              dense
+              outlined
+              required
             ></v-autocomplete>
           </v-col>
         </v-row>
 
         <v-row>
-          <v-col cols="8">
+          <v-col cols="6">
             <v-select
-              dense
-              outlined
-              hide-details
+              v-model="purchasedTypeId"
               :items="assetPurchaseTypeOptions"
               item-text="description"
               item-value="id"
               label="How were these items purchased?"
-              v-model="purchasedTypeId"
+              :rules="assetPurchaseTypeIdRules"
+              hide-details="auto"
+              dense
+              outlined
+              required
             ></v-select>
           </v-col>
-          <v-col cols="4">
+          <v-col cols="6">
             <v-text-field
               v-model="orderNumber"
               label="Order number"
+              :rules="orderNumberRules"
+              hide-details="auto"
               dense
               outlined
-              hide-details
+              required
             ></v-text-field>
           </v-col>
         </v-row>
 
         <div class="d-flex justify-end">
-          <v-btn class="mb-0" color="primary" @click="createTags">
+          <v-btn
+            class="mb-0"
+            color="primary"
+            :disabled="!valid"
+            @click="createTags"
+          >
             Generate tags
           </v-btn>
         </div>
       </v-container>
     </v-card>
     <notifications ref="notifier"></notifications>
-  </div>
+  </v-form>
 </template>
 
 <script>
@@ -141,13 +155,20 @@ export default {
   props: ["onSave"],
   data() {
     return {
-      assetTypeId: null,
-      menu: null,
+      datePickerMenu: false,
       orderNumber: null,
+      orderNumberRules: [(v) => !!v || "Order number is required"],
       purchaseDate: null,
       purchasedTypeId: null,
+      assetPurchaseTypeIdRules: [(v) => !!v || "Purchase type is required"],
       sendMailcodeId: -1,
+      sendMailcodeIdRules: [(v) => !!v || "Mailcode is required"],
       tagCount: 1,
+      tagCountRules: [
+        (v) => !!v || "Must request at least one tag",
+        (v) => v > 0 || "Must request at least one tag",
+      ],
+      valid: false,
     };
   },
   mounted() {

--- a/web/src/components/AssetRegisterForm.vue
+++ b/web/src/components/AssetRegisterForm.vue
@@ -20,7 +20,7 @@
     <v-card class="white" outlined>
       <v-container class="py-4">
         <v-row>
-          <v-col cols="4">
+          <v-col cols="12" sm="4">
             <v-text-field
               v-model="tagCount"
               :rules="tagCountRules"
@@ -38,7 +38,7 @@
             </v-text-field>
           </v-col>
 
-          <v-col cols="8">
+          <v-col cols="12" sm="8">
             <v-menu
               v-model="datePickerMenu"
               :close-on-content-click="false"
@@ -75,7 +75,7 @@
         </v-row>
 
         <v-row>
-          <v-col cols="12">
+          <v-col cols="12" sm="12">
             <v-autocomplete
               v-model="sendMailcodeId"
               :items="onlyKnownMailcodeOptions"
@@ -96,7 +96,7 @@
         </v-row>
 
         <v-row>
-          <v-col cols="6">
+          <v-col cols="12" sm="6">
             <v-select
               v-model="purchasedTypeId"
               :items="assetPurchaseTypeOptions"
@@ -114,7 +114,7 @@
               </template>
             </v-select>
           </v-col>
-          <v-col cols="6">
+          <v-col cols="12" sm="6">
             <v-text-field
               v-model="orderNumber"
               label="Order number"

--- a/web/src/components/AssetRegisterForm.vue
+++ b/web/src/components/AssetRegisterForm.vue
@@ -154,8 +154,11 @@ export default {
     this.purchaseDate = new Date().toISOString().slice(0, 10);
   },
   watch: {
-    currentUserMailcodeId(value) {
-      this.sendMailcodeId = value;
+    currentUserMailcodeId: {
+      handler(value) {
+        this.sendMailcodeId = value;
+      },
+      immediate: true,
     },
   },
   methods: {


### PR DESCRIPTION
Fixes https://github.com/icefoganalytics/asset-apps/issues/23

# Context
Some pre-release Tag Request form UI/UX tweaks.
- Make form a single pane (ditched the v-stepper).
- Remove the "type of item" select field; item_type_id is now set to -1.
- Make the "How many tags", "purchase date", "mail code", and "how purchased" fields required to activate the "Generate tags" button
- Order number is optional.

# Todo
- [x] re-add code for mobile rendering

# Screenshots
![image](https://user-images.githubusercontent.com/23045206/156828535-f69a12fa-6c93-4435-96a8-d688b3b6b0e4.png)
![image](https://user-images.githubusercontent.com/23045206/156828577-b3ce9167-4f70-426f-a3cd-b5de6aef19fc.png)

On Mobile
![image](https://user-images.githubusercontent.com/23045206/156830276-453c6f60-216c-4090-80b4-60f55e5cd36f.png)

