### PR TITLE
Fixup: Asset Registration Form Fails on Unknown asset types

### DIFF
--- a/api/src/routes/asset-tag-router.ts
+++ b/api/src/routes/asset-tag-router.ts
@@ -47,7 +47,8 @@ assetTagRouter.post("/", (req: Request, res: Response) => {
         .select("description")
         .from("asset_type")
         .where({ id: asset_type_id })
-        .first();
+        .first()
+        .then((result) => result || { description: "Unknown" });
 
       const { description: purchase_type } = await db
         .select("description")

--- a/web/src/components/AssetRegisterForm.vue
+++ b/web/src/components/AssetRegisterForm.vue
@@ -216,10 +216,15 @@ export default {
         })
       );
 
-      Promise.all(assetItemCreationPromises).then(() => {
-        this.$refs.notifier.showSuccess("Your tags have been generated.");
-        this.$router.push({ name: "MyTags" });
-      });
+      Promise.all(assetItemCreationPromises)
+        .then(() => {
+          this.$refs.notifier.showSuccess("Your tags have been generated.");
+          this.$router.push({ name: "MyTags" });
+        })
+        .catch((error) => {
+          console.error(error);
+          this.$refs.notifier.showError("Could not generate your tags.");
+        });
     },
   },
 };


### PR DESCRIPTION
Introduced in: https://github.com/icefoganalytics/asset-apps/pull/25

# Context
Permit soft handling of unknown asset types.

# Recreation Instructions

With a clean database (I really need to make a seed file for the db), attempt to register an asset via the dashboard widget. This will fail on `development` with the error `Cannot destructure property 'description' of '(intermediate value)' as it is undefined.`