### PR TITLE
Undo: Revert compostion pattern usage in UserService

### DIFF
--- a/api/src/middleware/index.ts
+++ b/api/src/middleware/index.ts
@@ -1,8 +1,11 @@
 import { NextFunction, Request, Response } from "express";
 import { validationResult } from "express-validator";
-import { UserService } from "../services";
 
-export async function ReturnValidationErrors(req: Request, res: Response, next: NextFunction) {
+export async function ReturnValidationErrors(
+    req: Request,
+    res: Response,
+    next: NextFunction
+) {
     const errors = validationResult(req);
 
     if (!errors.isEmpty()) {
@@ -12,10 +15,14 @@ export async function ReturnValidationErrors(req: Request, res: Response, next: 
     next();
 }
 
-export function RequiresAuthentication(req: Request, res: Response, next: NextFunction) {
+export function RequiresAuthentication(
+    req: Request,
+    res: Response,
+    next: NextFunction
+) {
     if (req.isAuthenticated()) {
         return next();
     }
 
-    res.redirect('/api/auth/login');
+    res.redirect("/api/auth/login");
 }

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -1,13 +1,13 @@
 import { Express, NextFunction, Request, Response } from "express";
 import * as ExpressSession from "express-session";
 
-import { db, AuthUser } from "../data";
+import { AuthUser } from "../data";
 import { AUTH_REDIRECT, FRONTEND_URL, V2_API_KEY_REMOTE } from "../config";
 import { UserService } from "../services";
 
 import { auth } from "express-openid-connect";
 
-const userService = new UserService(db);
+const userService = new UserService();
 
 const V2_API_REGEX = /^\/api\/v2\/.*/;
 

--- a/api/src/routes/user-router.ts
+++ b/api/src/routes/user-router.ts
@@ -8,7 +8,7 @@ import _ from "lodash";
 
 export const userRouter = express.Router();
 
-const userService = new UserService(db);
+const userService = new UserService();
 
 userRouter.get("/me", async (req: Request, res: Response) => {
     const currentUser = req.user;

--- a/api/src/services/user-service.ts
+++ b/api/src/services/user-service.ts
@@ -1,13 +1,9 @@
 import { Knex } from "knex";
 import _ from "lodash";
 
+import { db } from "../data";
+
 export class UserService {
-    readonly db: Knex;
-
-    constructor(db: Knex) {
-        this.db = db;
-    }
-
     async create(
         email: string,
         first_name: string,
@@ -15,9 +11,7 @@ export class UserService {
         status: string,
         roles: string
     ): Promise<any> {
-        let existing = await this.db("user")
-            .where({ email })
-            .count("email as cnt");
+        let existing = await db("user").where({ email }).count("email as cnt");
 
         if (existing[0].cnt > 0) return undefined;
 
@@ -30,19 +24,19 @@ export class UserService {
             create_date: new Date(),
         };
 
-        return await this.db("user").insert(user);
+        return await db("user").insert(user);
     }
 
     async update(email: string, item: any) {
-        return this.db("user").where({ email }).update(item);
+        return db("user").where({ email }).update(item);
     }
 
     async getAll() {
-        return this.db("user");
+        return db("user");
     }
 
     async getByEmail(email: string): Promise<any | undefined> {
-        return this.db("user").where({ email }).first();
+        return db("user").where({ email }).first();
     }
 
     async getAccessFor(email: string): Promise<string[]> {
@@ -62,7 +56,7 @@ export class UserService {
         dto.manage_mailcodes = _.split(userRaw.manage_mailcodes, ",").filter(
             (r: string) => r.length > 0
         );
-        //dto.access = await this.db.getAccessFor(userRaw.email);
+        //dto.access = await db.getAccessFor(userRaw.email);
         //dto.display_access = _.join(dto.access.map((a: any) => a.level), ", ")
 
         return dto;


### PR DESCRIPTION
# Context

We are attempting to debug why production version of the system is failing, even though it works in development. Posit that do to an older MSSql connection the composition pattern in the UserService might be causing a boot loop.
To that effect we are trying reverting the move to composition pattern for UserService.