### PR TITLE
Issue 35: Improve Transfer Delete Semantics

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,13 @@
+# .prettierrc or .prettierrc.yaml
+arrowParens: 'always'
+embeddedLanguageFormatting: 'auto'
+jsxSingleQuote: true
+pugAttributeSeparator: 'as-needed'
+pugSingleQuote: false
+pugWrapAttributesThreshold: 1
+semi: true
+singleAttributePerLine: true
+singleQuote: true
+tabWidth: 2
+trailingComma: 'es5'
+useTabs: true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains the source for all projects related to internal Asset M
 ```
 docker-compose -f docker-compose.dev.yaml up
 
-# or if you can run bash
+# or if you can run ruby
 bin/dev up
 ```
 

--- a/api/src/data/models/asset_transfer.ts
+++ b/api/src/data/models/asset_transfer.ts
@@ -1,4 +1,11 @@
-
 export interface asset_transfer {
-    id: number;
+  id: number;
+}
+
+export interface AssetTransferUpdate {
+  asset_category_id?: number;
+  condition: string;
+  from_owner_id?: number;
+  quantity?: number;
+  to_owner_id?: number;
 }

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -131,12 +131,12 @@ transferRouter.patch("/:id", async (req: Request, res: Response) => {
 });
 
 transferRouter.delete("/:id", async (req: Request, res: Response) => {
-  let { id } = req.params;
+  const id = parseInt(req.params.id);
 
-  await db("asset_transfer").where({ id }).delete();
-
-  return res.json({
-    data: {},
-    messages: [{ variant: "success", text: "Transfer removed" }],
-  });
+  return transferService.delete(id).then(() =>
+    res.json({
+      data: {},
+      messages: [{ variant: "success", text: "Transfer removed" }],
+    })
+  );
 });

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -1,142 +1,142 @@
-import express, { Request, Response } from "express";
-import { body } from "express-validator";
-import { SortDirection, SortStatement, TransferService } from "../services";
-import { ReturnValidationErrors } from "../middleware";
-import _ from "lodash";
+import express, { Request, Response } from 'express';
+import { body } from 'express-validator';
+import { SortDirection, SortStatement, TransferService } from '../services';
+import { ReturnValidationErrors } from '../middleware';
+import _ from 'lodash';
 
 export const transferRouter = express.Router();
 const PAGE_SIZE = 10;
 
-import { db, DB_TRUE } from "../data";
+import { db, DB_TRUE } from '../data';
 const transferService = new TransferService(db);
 
 transferRouter.post(
-  "/",
-  [body("page").isInt().default(1), body("itemsPerPage").isInt().default(10)],
-  async (req: Request, res: Response) => {
-    let { query, sortBy, sortDesc, page, itemsPerPage } = req.body;
-    let sort = new Array<SortStatement>();
+	'/',
+	[body('page').isInt().default(1), body('itemsPerPage').isInt().default(10)],
+	async (req: Request, res: Response) => {
+		let { query, sortBy, sortDesc, page, itemsPerPage } = req.body;
+		let sort = new Array<SortStatement>();
 
-    sortBy.forEach((s: string, i: number) => {
-      sort.push({
-        field: s,
-        direction: sortDesc[i]
-          ? SortDirection.ASCENDING
-          : SortDirection.DESCENDING,
-      });
-    });
+		sortBy.forEach((s: string, i: number) => {
+			sort.push({
+				field: s,
+				direction: sortDesc[i]
+					? SortDirection.ASCENDING
+					: SortDirection.DESCENDING,
+			});
+		});
 
-    let skip = (page - 1) * itemsPerPage;
-    let take = itemsPerPage;
+		let skip = (page - 1) * itemsPerPage;
+		let take = itemsPerPage;
 
-    let results = await transferService.doSearch(
-      query,
-      sort,
-      page,
-      itemsPerPage,
-      skip,
-      take
-    );
+		let results = await transferService.doSearch(
+			query,
+			sort,
+			page,
+			itemsPerPage,
+			skip,
+			take
+		);
 
-    return res.json(results);
-  }
+		return res.json(results);
+	}
 );
 
-transferRouter.post("/transfer", async (req: Request, res: Response) => {
-  let { from_owner_id, to_owner_id, rows, action } = req.body;
+transferRouter.post('/transfer', async (req: Request, res: Response) => {
+	let { from_owner_id, to_owner_id, rows, action } = req.body;
 
-  for (let row of rows) {
-    let transfer = {
-      asset_category_id: row.type,
-      request_user: req.user.email,
-      request_date: new Date(),
-      transfer_date: new Date(),
-      condition: row.condition,
-      from_owner_id,
-      to_owner_id,
-      quantity: row.quantity,
-      description: row.tag,
-    };
+	for (let row of rows) {
+		let transfer = {
+			asset_category_id: row.type,
+			request_user: req.user.email,
+			request_date: new Date(),
+			transfer_date: new Date(),
+			condition: row.condition,
+			from_owner_id,
+			to_owner_id,
+			quantity: row.quantity,
+			description: row.tag,
+		};
 
-    await db("asset_transfer").insert(transfer);
-  }
+		await db('asset_transfer').insert(transfer);
+	}
 
-  return res.json({
-    messages: { variant: "success", text: "Transfer saved" },
-  });
+	return res.json({
+		messages: { variant: 'success', text: 'Transfer saved' },
+	});
 });
 
 transferRouter.post(
-  "/transfer-request",
-  async (req: Request, res: Response) => {
-    let { asset, fromOwnerId, rows, condition } = req.body;
-    const default_owner = await db("asset_owner")
-      .where({ default_owner: DB_TRUE })
-      .first();
+	'/transfer-request',
+	async (req: Request, res: Response) => {
+		let { asset, fromOwnerId, rows, condition } = req.body;
+		const default_owner = await db('asset_owner')
+			.where({ default_owner: DB_TRUE })
+			.first();
 
-    if (asset) {
-      let transfer = {
-        asset_item_id: asset.id,
-        request_user: req.user.email,
-        request_date: new Date(),
-        transfer_date: new Date(),
-        condition: `REQUEST: ${condition}`,
-        from_owner_id: fromOwnerId,
-        to_owner_id: default_owner.id,
-        quantity: 1,
-      };
+		if (asset) {
+			let transfer = {
+				asset_item_id: asset.id,
+				request_user: req.user.email,
+				request_date: new Date(),
+				transfer_date: new Date(),
+				condition: `REQUEST: ${condition}`,
+				from_owner_id: fromOwnerId,
+				to_owner_id: default_owner.id,
+				quantity: 1,
+			};
 
-      await db("asset_transfer").insert(transfer);
-    } else {
-      for (let row of rows) {
-        let transfer = {
-          asset_category_id: row.type,
-          request_user: req.user.email,
-          request_date: new Date(),
-          transfer_date: new Date(),
-          condition: `REQUEST: ${row.condition}`,
-          from_owner_id: fromOwnerId,
-          to_owner_id: default_owner.id,
-          quantity: row.quantity,
-        };
+			await db('asset_transfer').insert(transfer);
+		} else {
+			for (let row of rows) {
+				let transfer = {
+					asset_category_id: row.type,
+					request_user: req.user.email,
+					request_date: new Date(),
+					transfer_date: new Date(),
+					condition: `REQUEST: ${row.condition}`,
+					from_owner_id: fromOwnerId,
+					to_owner_id: default_owner.id,
+					quantity: row.quantity,
+				};
 
-        await db("asset_transfer").insert(transfer);
-      }
-    }
+				await db('asset_transfer').insert(transfer);
+			}
+		}
 
-    return res.json({
-      messages: { variant: "success", text: "Transfer saved" },
-    });
-  }
+		return res.json({
+			messages: { variant: 'success', text: 'Transfer saved' },
+		});
+	}
 );
 
-transferRouter.patch("/:id", async (req: Request, res: Response) => {
-  const { id } = req.params;
+transferRouter.patch('/:id', async (req: Request, res: Response) => {
+	const { id } = req.params;
 
-  const { asset_category_id, condition, from_owner_id, quantity, to_owner_id } =
-    req.body;
+	const { asset_category_id, condition, from_owner_id, quantity, to_owner_id } =
+		req.body;
 
-  await db("asset_transfer").where({ id }).update({
-    asset_category_id,
-    condition,
-    from_owner_id,
-    quantity,
-    to_owner_id,
-  });
+	await db('asset_transfer').where({ id }).update({
+		asset_category_id,
+		condition,
+		from_owner_id,
+		quantity,
+		to_owner_id,
+	});
 
-  return res.json({
-    data: {},
-    messages: [{ variant: "success", text: "Transfer saved" }],
-  });
+	return res.json({
+		data: {},
+		messages: [{ variant: 'success', text: 'Transfer saved' }],
+	});
 });
 
-transferRouter.delete("/:id", async (req: Request, res: Response) => {
-  const id = parseInt(req.params.id);
+transferRouter.delete('/:id', async (req: Request, res: Response) => {
+	const id = parseInt(req.params.id);
 
-  return transferService.delete(id).then(() =>
-    res.json({
-      data: {},
-      messages: [{ variant: "success", text: "Transfer removed" }],
-    })
-  );
+	return transferService.delete(id).then(() =>
+		res.json({
+			data: {},
+			messages: [{ variant: 'success', text: 'Transfer removed' }],
+		})
+	);
 });

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from 'express';
 import { body } from 'express-validator';
 import { SortDirection, SortStatement, TransferService } from '../services';
 import { ReturnValidationErrors } from '../middleware';
-import _ from 'lodash';
+import { pick } from 'lodash';
 
 export const transferRouter = express.Router();
 const PAGE_SIZE = 10;
@@ -110,24 +110,23 @@ transferRouter.post(
 	}
 );
 
-transferRouter.patch('/:id', async (req: Request, res: Response) => {
-	const { id } = req.params;
+transferRouter.patch('/:id', (req: Request, res: Response) => {
+	const id = parseInt(req.params.id);
 
-	const { asset_category_id, condition, from_owner_id, quantity, to_owner_id } =
-		req.body;
+	const attributes = pick(req.body, [
+		'asset_category_id',
+		'condition',
+		'from_owner_id',
+		'quantity',
+		'to_owner_id',
+	]);
 
-	await db('asset_transfer').where({ id }).update({
-		asset_category_id,
-		condition,
-		from_owner_id,
-		quantity,
-		to_owner_id,
-	});
-
-	return res.json({
-		data: {},
-		messages: [{ variant: 'success', text: 'Transfer saved' }],
-	});
+	return transferService.update(id, attributes).then(() =>
+		res.json({
+			data: {},
+			messages: [{ variant: 'success', text: 'Transfer saved' }],
+		})
+	);
 });
 
 transferRouter.delete('/:id', async (req: Request, res: Response) => {

--- a/api/src/routes/asset-transfer-router.ts
+++ b/api/src/routes/asset-transfer-router.ts
@@ -121,21 +121,50 @@ transferRouter.patch('/:id', (req: Request, res: Response) => {
 		'to_owner_id',
 	]);
 
-	return transferService.update(id, attributes).then(() =>
-		res.json({
-			data: {},
-			messages: [{ variant: 'success', text: 'Transfer saved' }],
-		})
-	);
+	return transferService
+		.update(id, attributes)
+		.then(() =>
+			res.json({
+				data: {},
+				messages: [{ variant: 'success', text: 'Transfer saved' }],
+			})
+		)
+		.catch((error) =>
+			res.status(422).json({
+				messages: [
+					{
+						variant: 'error',
+						text: 'Failed to update transfer',
+						details: error.message,
+					},
+				],
+			})
+		);
 });
 
-transferRouter.delete('/:id', async (req: Request, res: Response) => {
-	const id = parseInt(req.params.id);
+transferRouter.delete(
+	'/:id',
+	async (req: Request, res: Response) => {
+		const id = parseInt(req.params.id);
 
-	return transferService.delete(id).then(() =>
-		res.json({
-			data: {},
-			messages: [{ variant: 'success', text: 'Transfer removed' }],
-		})
-	);
-});
+		return transferService
+			.delete(id)
+			.then(() =>
+				res.json({
+					data: {},
+					messages: [{ variant: 'success', text: 'Transfer removed' }],
+				})
+			)
+			.catch((error) =>
+				res.status(422).json({
+					messages: [
+						{
+							variant: 'error',
+							text: 'Failed to remove transfer',
+							details: error.message,
+						},
+					],
+				})
+			);
+	}
+);

--- a/api/src/services/transfer-service.ts
+++ b/api/src/services/transfer-service.ts
@@ -190,7 +190,10 @@ export class TransferService {
 				)
 					return;
 
-				return this.transferAsset(assetItemId, toOwnerId);
+				return this.db.from('asset_item').where({ id: assetItemId }).update({
+					asset_owner_id: toOwnerId,
+					status: newCondition,
+				});
 			})
 			.then(() =>
 				this.db.from('asset_transfer').where({ id }).update(newAttributes)

--- a/api/src/services/transfer-service.ts
+++ b/api/src/services/transfer-service.ts
@@ -200,9 +200,9 @@ export class TransferService {
 	delete(id: number) {
 		return this.db
 			.select({
-				assetItemId: 'asset_item.id',
-				tag: 'asset_item.tag',
+				assetItemId: 'asset_transfer.asset_item_id',
 				fromOwnerId: 'asset_transfer.from_owner_id',
+				tag: 'asset_item.tag',
 			})
 			.where({ 'asset_transfer.id': id })
 			.from('asset_transfer')
@@ -211,10 +211,7 @@ export class TransferService {
 			.then(({ assetItemId, tag, fromOwnerId }) => {
 				if ([null, undefined, ''].includes(tag)) return;
 
-				return this.db.from('asset_item').where({ id: assetItemId }).update({
-					asset_owner_id: fromOwnerId,
-					status: 'Active',
-				});
+				return this.transferAsset(assetItemId, fromOwnerId);
 			})
 			.then(() => this.db('asset_transfer').where({ id }).delete());
 	}

--- a/api/src/services/transfer-service.ts
+++ b/api/src/services/transfer-service.ts
@@ -190,13 +190,13 @@ export class TransferService {
 				)
 					return;
 
-				return this.db.from('asset_item').where({ id: assetItemId }).update({
+				return this.db('asset_item').where({ id: assetItemId }).update({
 					asset_owner_id: toOwnerId,
 					status: newCondition,
 				});
 			})
 			.then(() =>
-				this.db.from('asset_transfer').where({ id }).update(newAttributes)
+				this.db('asset_transfer').where({ id }).update(newAttributes)
 			);
 	}
 
@@ -214,16 +214,11 @@ export class TransferService {
 			.then(({ assetItemId, tag, fromOwnerId }) => {
 				if ([null, undefined, ''].includes(tag)) return;
 
-				return this.transferAsset(assetItemId, fromOwnerId);
+				return this.db('asset_item').where({ id: assetItemId }).update({
+					asset_owner_id: fromOwnerId,
+					status: 'Active',
+				});
 			})
 			.then(() => this.db('asset_transfer').where({ id }).delete());
-	}
-
-	// helpers
-	transferAsset(assetItemId: number, assetOwnerId: number) {
-		this.db.from('asset_item').where({ id: assetItemId }).update({
-			asset_owner_id: assetOwnerId,
-			status: 'Active',
-		});
 	}
 }

--- a/api/src/services/transfer-service.ts
+++ b/api/src/services/transfer-service.ts
@@ -1,210 +1,194 @@
-import { Knex } from "knex";
-import _ from "lodash";
-import moment from "moment";
-import { QueryStatement, SortStatement } from ".";
+import { Knex } from 'knex';
+import _ from 'lodash';
+import moment from 'moment';
+import { QueryStatement, SortStatement } from '.';
 
 export class TransferService {
-    readonly db: Knex;
+	readonly db: Knex;
 
-    constructor(db: Knex) {
-        this.db = db;
-    }
+	constructor(db: Knex) {
+		this.db = db;
+	}
 
-    async doSearch(
-        query: Array<QueryStatement>,
-        sort: Array<SortStatement>,
-        page: number,
-        page_size: number,
-        skip: number,
-        take: number
-    ): Promise<any> {
-        return new Promise(async (resolve, reject) => {
-            let selectStmt = this.db("asset_transfer")
-                .select("asset_transfer.*")
-                .leftJoin(
-                    "asset_item",
-                    "asset_transfer.asset_item_id",
-                    "asset_item.id"
-                )
-                .leftJoin(
-                    "asset_category",
-                    "asset_transfer.asset_category_id",
-                    "asset_category.id"
-                );
+	async doSearch(
+		query: Array<QueryStatement>,
+		sort: Array<SortStatement>,
+		page: number,
+		page_size: number,
+		skip: number,
+		take: number
+	): Promise<any> {
+		return new Promise(async (resolve, reject) => {
+			let selectStmt = this.db('asset_transfer')
+				.select('asset_transfer.*')
+				.leftJoin('asset_item', 'asset_transfer.asset_item_id', 'asset_item.id')
+				.leftJoin(
+					'asset_category',
+					'asset_transfer.asset_category_id',
+					'asset_category.id'
+				);
 
-            if (query && query.length > 0) {
-                query.forEach((stmt: any) => {
-                    switch (stmt.operator) {
-                        case "eq": {
-                            let p = {};
-                            let m = `{"${stmt.field}": "${stmt.value}"}`;
-                            Object.assign(p, JSON.parse(m));
-                            selectStmt.where(p);
-                            break;
-                        }
-                        case "in": {
-                            let items = stmt.value.split(",");
-                            selectStmt.whereIn(stmt.field, items);
-                            break;
-                        }
-                        case "notin": {
-                            let items = stmt.value.split(",");
-                            selectStmt.whereNotIn(stmt.field, items);
-                            break;
-                        }
-                        case "gt": {
-                            selectStmt.where(stmt.field, ">", stmt.value);
-                            break;
-                        }
-                        case "gte": {
-                            selectStmt.where(stmt.field, ">=", stmt.value);
-                            break;
-                        }
-                        case "lt": {
-                            selectStmt.where(stmt.field, "<", stmt.value);
-                            break;
-                        }
-                        case "lte": {
-                            console.log(
-                                `Testing ${stmt.field} for IN on ${stmt.value}`
-                            );
-                            selectStmt.where(stmt.field, "<=", stmt.value);
-                            break;
-                        }
-                        case "contains": {
-                            if (stmt.fields) {
-                                let raws = [];
-                                for (let field of stmt.fields) {
-                                    raws.push(
-                                        `LOWER(${field}) like '%${stmt.value
-                                            .replace("'", "")
-                                            .toLowerCase()}%'`
-                                    );
-                                }
-                                selectStmt.whereRaw(`(${raws.join(" OR ")})`);
-                            } else {
-                                selectStmt.whereRaw(
-                                    `LOWER(${stmt.field}) like '%${stmt.value
-                                        .replace("'", "")
-                                        .toLowerCase()}%'`
-                                );
-                            }
+			if (query && query.length > 0) {
+				query.forEach((stmt: any) => {
+					switch (stmt.operator) {
+						case 'eq': {
+							let p = {};
+							let m = `{"${stmt.field}": "${stmt.value}"}`;
+							Object.assign(p, JSON.parse(m));
+							selectStmt.where(p);
+							break;
+						}
+						case 'in': {
+							let items = stmt.value.split(',');
+							selectStmt.whereIn(stmt.field, items);
+							break;
+						}
+						case 'notin': {
+							let items = stmt.value.split(',');
+							selectStmt.whereNotIn(stmt.field, items);
+							break;
+						}
+						case 'gt': {
+							selectStmt.where(stmt.field, '>', stmt.value);
+							break;
+						}
+						case 'gte': {
+							selectStmt.where(stmt.field, '>=', stmt.value);
+							break;
+						}
+						case 'lt': {
+							selectStmt.where(stmt.field, '<', stmt.value);
+							break;
+						}
+						case 'lte': {
+							console.log(`Testing ${stmt.field} for IN on ${stmt.value}`);
+							selectStmt.where(stmt.field, '<=', stmt.value);
+							break;
+						}
+						case 'contains': {
+							if (stmt.fields) {
+								let raws = [];
+								for (let field of stmt.fields) {
+									raws.push(
+										`LOWER(${field}) like '%${stmt.value
+											.replace("'", '')
+											.toLowerCase()}%'`
+									);
+								}
+								selectStmt.whereRaw(`(${raws.join(' OR ')})`);
+							} else {
+								selectStmt.whereRaw(
+									`LOWER(${stmt.field}) like '%${stmt.value
+										.replace("'", '')
+										.toLowerCase()}%'`
+								);
+							}
 
-                            break;
-                        }
-                        default: {
-                            console.log(
-                                `IGNORING ${stmt.field} on ${stmt.value}`
-                            );
-                        }
-                    }
-                });
-            }
+							break;
+						}
+						default: {
+							console.log(`IGNORING ${stmt.field} on ${stmt.value}`);
+						}
+					}
+				});
+			}
 
-            if (sort && sort.length > 0) {
-                sort.forEach((stmt) => {
-                    selectStmt.orderBy(stmt.field, stmt.direction);
-                });
-            } else {
-                selectStmt.orderBy("asset_transfer.request_date", "desc");
-            }
+			if (sort && sort.length > 0) {
+				sort.forEach((stmt) => {
+					selectStmt.orderBy(stmt.field, stmt.direction);
+				});
+			} else {
+				selectStmt.orderBy('asset_transfer.request_date', 'desc');
+			}
 
-            //console.log(selectStmt.toSQL().toNative())
+			//console.log(selectStmt.toSQL().toNative())
 
-            let fullData = await selectStmt;
-            let uniqIds = _.uniq(fullData.map((i) => i.id));
-            let count = uniqIds.length;
-            let page_count = Math.ceil(count / page_size);
+			let fullData = await selectStmt;
+			let uniqIds = _.uniq(fullData.map((i) => i.id));
+			let count = uniqIds.length;
+			let page_count = Math.ceil(count / page_size);
 
-            let data = await selectStmt.offset(skip).limit(take);
+			let data = await selectStmt.offset(skip).limit(take);
 
-            let categories = await this.db("asset_category");
+			let categories = await this.db('asset_category');
 
-            for (let item of data) {
-                item.transfer_date = moment(item.transfer_date)
-                    .utc(true)
-                    .format("YYYY-MM-DD");
+			for (let item of data) {
+				item.transfer_date = moment(item.transfer_date)
+					.utc(true)
+					.format('YYYY-MM-DD');
 
-                if (item.asset_category_id) {
-                    let category = categories.filter(
-                        (cat) => cat.id == item.asset_category_id
-                    );
+				if (item.asset_category_id) {
+					let category = categories.filter(
+						(cat) => cat.id == item.asset_category_id
+					);
 
-                    if (category.length > 0) {
-                        if (item.description) {
-                            item.asset_item = { tag: item.description };
-                        }
+					if (category.length > 0) {
+						if (item.description) {
+							item.asset_item = { tag: item.description };
+						}
 
-                        item.description = `${category[0].description} (${item.quantity} items)`;
-                    }
-                }
+						item.description = `${category[0].description} (${item.quantity} items)`;
+					}
+				}
 
-                if (item.asset_item_id) {
-                    item.asset_item = await this.db("asset_item")
-                        .where({ id: item.asset_item_id })
-                        .first();
-                    item.description = item.asset_item.description;
-                }
+				if (item.asset_item_id) {
+					item.asset_item = await this.db('asset_item')
+						.where({ id: item.asset_item_id })
+						.first();
+					item.description = item.asset_item.description;
+				}
 
-                if (item.from_owner_id) {
-                    item.from_owner = await this.db("asset_owner")
-                        .where({ id: item.from_owner_id })
-                        .first();
-                    if (item.from_owner_id == -1)
-                        item.from_owner.display_name =
-                            "Unknown : " + item.from_owner_mailcode;
-                    else
-                        item.from_owner.display_name = `(${item.from_owner.mailcode}) ${item.from_owner.name}`;
-                }
+				if (item.from_owner_id) {
+					item.from_owner = await this.db('asset_owner')
+						.where({ id: item.from_owner_id })
+						.first();
+					if (item.from_owner_id == -1)
+						item.from_owner.display_name =
+							'Unknown : ' + item.from_owner_mailcode;
+					else
+						item.from_owner.display_name = `(${item.from_owner.mailcode}) ${item.from_owner.name}`;
+				}
 
-                if (item.to_owner_id) {
-                    item.to_owner = await this.db("asset_owner")
-                        .where({ id: item.to_owner_id })
-                        .first();
+				if (item.to_owner_id) {
+					item.to_owner = await this.db('asset_owner')
+						.where({ id: item.to_owner_id })
+						.first();
 
-                    if (item.to_owner_id == -1)
-                        item.to_owner.display_name =
-                            "Unknown : " + item.to_owner_mailcode;
-                    else
-                        item.to_owner.display_name = `(${item.to_owner.mailcode}) ${item.to_owner.name}`;
-                }
-            }
+					if (item.to_owner_id == -1)
+						item.to_owner.display_name = 'Unknown : ' + item.to_owner_mailcode;
+					else
+						item.to_owner.display_name = `(${item.to_owner.mailcode}) ${item.to_owner.name}`;
+				}
+			}
 
-            let results = {
-                data,
-                meta: { page, page_size, item_count: count, page_count },
-            };
+			let results = {
+				data,
+				meta: { page, page_size, item_count: count, page_count },
+			};
 
-            resolve(results);
-        });
-    }
+			resolve(results);
+		});
+	}
 
-    delete(id: number) {
-        return this.db
-            .select({
-                assetItemId: "asset_item.id",
-                tag: "asset_item.tag",
-                fromOwnerId: "asset_transfer.from_owner_id",
-            })
-            .where({ "asset_transfer.id": id })
-            .from("asset_transfer")
-            .innerJoin(
-                "asset_item",
-                "asset_item.id",
-                "asset_transfer.asset_item_id"
-            )
-            .first()
-            .then(({ assetItemId, tag, fromOwnerId }) => {
-                if ([null, undefined, ""].includes(tag)) return;
+	delete(id: number) {
+		return this.db
+			.select({
+				assetItemId: 'asset_item.id',
+				tag: 'asset_item.tag',
+				fromOwnerId: 'asset_transfer.from_owner_id',
+			})
+			.where({ 'asset_transfer.id': id })
+			.from('asset_transfer')
+			.innerJoin('asset_item', 'asset_item.id', 'asset_transfer.asset_item_id')
+			.first()
+			.then(({ assetItemId, tag, fromOwnerId }) => {
+				if ([null, undefined, ''].includes(tag)) return;
 
-                return this.db
-                    .from("asset_item")
-                    .where({ id: assetItemId })
-                    .update({
-                        asset_owner_id: fromOwnerId,
-                        status: "Active",
-                    });
-            })
-            .then(() => this.db("asset_transfer").where({ id }).delete());
-    }
+				return this.db.from('asset_item').where({ id: assetItemId }).update({
+					asset_owner_id: fromOwnerId,
+					status: 'Active',
+				});
+			})
+			.then(() => this.db('asset_transfer').where({ id }).delete());
+	}
 }

--- a/api/src/services/transfer-service.ts
+++ b/api/src/services/transfer-service.ts
@@ -178,4 +178,33 @@ export class TransferService {
             resolve(results);
         });
     }
+
+    delete(id: number) {
+        return this.db
+            .select({
+                assetItemId: "asset_item.id",
+                tag: "asset_item.tag",
+                fromOwnerId: "asset_transfer.from_owner_id",
+            })
+            .where({ "asset_transfer.id": id })
+            .from("asset_transfer")
+            .innerJoin(
+                "asset_item",
+                "asset_item.id",
+                "asset_transfer.asset_item_id"
+            )
+            .first()
+            .then(({ assetItemId, tag, fromOwnerId }) => {
+                if ([null, undefined, ""].includes(tag)) return;
+
+                return this.db
+                    .from("asset_item")
+                    .where({ id: assetItemId })
+                    .update({
+                        asset_owner_id: fromOwnerId,
+                        status: "Active",
+                    });
+            })
+            .then(() => this.db("asset_transfer").where({ id }).delete());
+    }
 }

--- a/bin/dev
+++ b/bin/dev
@@ -54,6 +54,7 @@ class DevHelper
       *%W[-P #{db_pass}],
       *%W[-H #{db_host}],
       *%W[-d #{db_name}],
+      '-I', # enable quoted identifiers, e.g. "table"."column"
       *args,
     )
   end

--- a/bin/dev
+++ b/bin/dev
@@ -1,58 +1,65 @@
-#!/usr/bin/env bash
+#!/usr/bin/env ruby
 
-# Helpers
-dc () {
-	docker-compose -f docker-compose.dev.yaml "$@"
-}
+class DevHelper
+  def self.call(*args)
+    self.new.call(*args)
+  end
 
-function_exists () {
-	declare -F "$1" > /dev/null
-}
+  # Core logic
+  def call(*args)
+    if args.length.zero?
+      dc(*args)
+    elsif respond_to?(args[0])
+      public_send(args[0], args.drop(1))
+    else
+      dc(*args)
+    end
+  end
 
-# Docker Compose overrides
-build () {
-	echo "not yet implemented"
-}
+  def dc(*args)
+    puts "Running: docker-compose -f docker-compose.dev.yaml #{args.join(' ')}"
+    exec("docker-compose -f docker-compose.dev.yaml #{args.join(' ')}")
+  end
 
-up () {
-	dc up --remove-orphans "$@"
-}
+  def build(*args)
+    dc(%w[build], *args)
+  end
 
-down () {
-	dc down --remove-orphans "$@"
-}
+  def up(*args)
+    dc(*%w[up --remove-orphans], *args)
+  end
 
-logs () {
-	dc logs -f "$@"
-}
+  def down(*args)
+    dc(*%w[down --remove-orphans], *args)
+  end
 
-# Custom helpers
-refresh () {
-	down
-	up
-}
+  def logs(*args)
+    dc(*%w[logs -f], *args)
+  end
 
-sqlcmd () {
-	dc exec db /opt/mssql-tools/bin/sqlcmd \
-			-U sa \
-			-P Testing1122 \
-			-H localhost \
-			-d AssetControl \
-			"$@"
-}
+  # Custom helpers
+  def refresh
+    down
+    up
+  end
 
-# Core logic
-main () {
-	local_function="$1"
-	if function_exists $1; then
-		shift
-		eval "$local_function" "$@"
-	else
-		dc "$@"
-	fi
-}
+  def sqlcmd(*args)
+    db_host = ENV.fetch('DB_HOST', 'localhost')
+    db_user = ENV.fetch('DB_USER', 'sa')
+    db_pass = ENV.fetch('DB_PASS', 'Testing1122')
+    db_name = ENV.fetch('DB_NAME', 'AssetControl')
+    dc(
+      *%w[exec db /opt/mssql-tools/bin/sqlcmd],
+      *%W[-U #{db_user}],
+      *%W[-P #{db_pass}],
+      *%W[-H #{db_host}],
+      *%W[-d #{db_name}],
+      *args,
+    )
+  end
+end
 
 # Only execute main function when file is executed
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-	main "$@"
-fi
+if $PROGRAM_NAME == __FILE__
+  DevHelper.call(*ARGV)
+end

--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "trailingComma": "es5",
-  "arrowParens": "always"
-}

--- a/web/src/components/transfers/TransferEditor.vue
+++ b/web/src/components/transfers/TransferEditor.vue
@@ -106,7 +106,7 @@
       </div>
 
       <v-btn color="error" :loading="loading" @click="confirmDelete"
-        >Remove</v-btn
+        >Revert</v-btn
       >
       <v-btn
         color="primary"
@@ -118,16 +118,17 @@
 
       <v-dialog v-model="isShowingDeleteDialog" max-width="400">
         <v-card>
-          <v-card-title>Remove Transfer</v-card-title>
+          <v-card-title>Revert Transfer</v-card-title>
           <v-card-text>
             <p>
-              Are you sure you want to permanently remove this transfer record?
+              Are you sure you want to revert and permanently remove this
+              transfer record?
             </p>
 
             <p class="text-error mb-0">
               <em
-                >* This action does not change the ownership of any attached
-                asset or its condition.</em
+                >* This action returns the attached tagged asset to its original
+                owner and sets its status to active.</em
               >
             </p>
           </v-card-text>

--- a/web/src/components/transfers/TransferEditor.vue
+++ b/web/src/components/transfers/TransferEditor.vue
@@ -136,7 +136,7 @@
           <v-card-actions>
             <v-spacer></v-spacer>
             <v-btn color="info" @click="cancelDelete">No</v-btn>
-            <v-btn color="error" @click="deleteConfirmed">Yes, Remove</v-btn>
+            <v-btn color="error" @click="deleteConfirmed">Yes, Revert</v-btn>
           </v-card-actions>
         </v-card>
       </v-dialog>


### PR DESCRIPTION
Fixes #35.

# User Story
1. When an admin reverts a transfer, the status of the associated asset is set back to "Active" and the asset regains its original owner.
2. When an admin accepts a requested transfer (i.e. a transfer with condition REQUEST: xxxx) it sets the asset owner to the requested owner and sets the asset status to the requested condition.

# Implementation
If the transfer is for a tagged asset:
 - The `asset_item.asset_owner_id` on the asset record is assigned back to the asset_transfer.from_owner_id from the transfer
 - The `asset_item.status` is be changed to "Active"

Update wording around transfer reversion.

# Screenshots
![image](https://user-images.githubusercontent.com/23045206/161356294-8e429f7d-6a5b-4e26-b3ca-875e03888d65.png)
